### PR TITLE
VULNERABILITY_RESPONSE_PROCESS.md: Better headings

### DIFF
--- a/VULNERABILITY_RESPONSE_PROCESS.md
+++ b/VULNERABILITY_RESPONSE_PROCESS.md
@@ -15,9 +15,9 @@
 
 5. Bounty will not be available for **Kovri** until **Kovri Beta** is released
 
-## I. Points of Contact for Security Issues
+## I. Points of contact for security issues
 
-### Monero (CLI/GUI/Website)
+### Monero (CLI/GUI/website)
 
 ```
 ric [at] getmonero.org
@@ -42,14 +42,14 @@ anonimal [at] mail.i2p
 PGP key fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
 ```
 
-## II. Security Response Team
+## II. Security response team
 
 - fluffypony
 - luigi1111
 - moneromooo
 - anonimal
 
-## III. Incident Response
+## III. Incident response
 
 1. Researcher submits report via one or both of two methods:
     - a. Email
@@ -96,13 +96,13 @@ PGP key fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
     - b. Response Manager includes vulnerability announcement draft in release notes
     - c. Proceed with the Point or Regular Release
 
-## IV. Post-release Disclosure Process
+## IV. Post-release disclosure process
 
 1. Response Team has 90 days to fulfill all points within section III
 
 2. If the Incident Response process in section III is successfully completed:
     - a. Response Manager contacts researcher and asks if researcher wishes for credit
-      - i. If bounty is applicable, release bounty to the researcher as defined in secion "Bounty Distribution"
+      - i. If bounty is applicable, release bounty to the researcher as defined in section "Bounty Distribution"
     - b. Finalize vulnerability announcement draft and include the following:
       - i. Project name and URL
       - ii. Versions known to be affected
@@ -127,7 +127,7 @@ PGP key fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
     - c. If disputes arise about whether or when to disclose information about a vulnerability, the Response Team will publicly discuss the issue via IRC and attempt to reach consensus
     - d. If consensus on a timely disclosure is not met (no later than 90 days), the researcher (after 90 days) has every right to expose the vulnerability to the public
 
-## V. Bounty Distribution
+## V. Bounty distribution
 
 - Total availability of XMR bounty can be tracked [here](https://forum.getmonero.org/8/funding-required/87597/monero-bounty-for-hackerone). XMR market values can be found at the various exchanges. See also [Cryptowatch](https://cryptowat.ch/) and [Live Coin Watch](https://www.livecoinwatch.com/).
 - As reports come in and payouts are made, the total bounty supply shrinks. This gives incentive for bug hunters to report bugs a.s.a.p.
@@ -137,7 +137,7 @@ PGP key fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
   3. 60% for HIGH severity bugs
 - Each bug will at most receive 10% of each category. Example: 10% of 60% for a HIGH severity bug.
 
-## VI. Incident Analysis
+## VI. Incident analysis
 
 1. Isolate codebase
     - a. Response Team and developers should coordinate to work on the following:
@@ -171,7 +171,7 @@ Any further questions or resolutions regarding the incident(s) between the resea
 - [Reddit /r/Kovri](https://reddit.com/r/Kovri/)
 - Email
 
-## VIII. Continuous Improvement
+## VIII. Continuous improvement
 
 1. Response Team and developers should hold annual meetings to review the previous year's incidents
 


### PR DESCRIPTION
See: https://github.com/monero-project/monero/pull/2881

This proposal seeks to put the heading capitalization policy inline with the main Monero readme. Capitalizing every single word in a heading begins to feel redundant and cumbersome when headings become long (and many are indeed quite long). A much better practice is capitalizing just the initial word.