### PR TITLE
Vulnerability response: Prefer to use Email + GPG

### DIFF
--- a/VULNERABILITY_RESPONSE_PROCESS.md
+++ b/VULNERABILITY_RESPONSE_PROCESS.md
@@ -52,7 +52,7 @@ PGP key fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
 ## III. Incident response
 
 1. Researcher submits report via one or both of two methods:
-    - a. Email
+    - a. PGP encrypted Email (use the appropriate fingerprints [listed in section I](#i-points-of-contact-for-security-issues) or as included in the Monero repo in `utils/gpg_keys/`)
     - b. [HackerOne](https://hackerone.com/monero)
 
 2. Response Team designates a Response Manager who is in charge of the particular report based on availability and/or knowledge-set


### PR DESCRIPTION
One shouldn't report vulnerabilities to a 3rd party service. It might still be better than plain text email though.