### PR TITLE
Specify (even more) explicitly that XMR bounties are paid by the community

### DIFF
--- a/VULNERABILITY_RESPONSE_PROCESS.md
+++ b/VULNERABILITY_RESPONSE_PROCESS.md
@@ -140,7 +140,7 @@ PGP fingerprint = 1218 6272 CD48 E253 9E2D  D29B 66A7 6ECF 9144 09F1
 
 ## V. Bounty distribution
 
-- Total availability of XMR bounty can be tracked [here](https://forum.getmonero.org/8/funding-required/87597/monero-bounty-for-hackerone). XMR market values can be found at the various exchanges. See also [Cryptowatch](https://cryptowat.ch/) and [Live Coin Watch](https://www.livecoinwatch.com/).
+- XMR for vulnerability-related bounties are solely contributed by community donators and escrowed by unpaid volunteers. Total availability of XMR contributed for bounties can be tracked [here](https://forum.getmonero.org/8/funding-required/87597/monero-bounty-for-hackerone). XMR market values can be found at the various exchanges. See also [Cryptowatch](https://cryptowat.ch/) and [Live Coin Watch](https://www.livecoinwatch.com/).
 - As reports come in and payouts are made, the total bounty supply shrinks. This gives incentive for bug hunters to report bugs a.s.a.p.
 - The following percentages apply to available XMR bounty (severity is defined above in section III. 6.):
   1. 10% reserved for LOW severity bugs


### PR DESCRIPTION
This is just very minor rewording to be absolutely explicit about where the Monero vulnerability bounties funds are coming from.   
   
Recent developments (see below -- in the context of Ethereum) show that regulation may take into account whether such bounties are paid from a centralized entity or not. This PR just adds extra clarity to explain the origin of funds.

> "Regulators have studied the role of central actors, such as Ethereum Foundation, which developed ether and oversees improvements to its software network, in driving the asset’s value [...] The foundation, for instance, pays “bug bounties,” which reward programmers who fix vulnerabilities in ether’s code, showing the nonprofit influences improvements that can boost the virtual currency’s value, one of the people familiar with the matter said".

Source [here](https://www.wsj.com/articles/worlds-second-most-valuable-cryptocurrency-under-regulatory-scrutiny-1525167000)
