### PR TITLE
Support subaddresses in light wallet API

### DIFF
--- a/api/lightwallet_rest.md
+++ b/api/lightwallet_rest.md
@@ -231,7 +231,7 @@ of subaddresses within that major index.
 
 |       |             Type              |                Description              |
 |-------|-------------------------------|-----------------------------------------|
-| Key   | `uint32-string`               | Subaddress major index                  |
+| Key   | `uint32`                      | Subaddress major index                  |
 | Value | array of `index_range` arrays | Minor subaddresses within the the major |
 
 > Minor subaddresses are in strictly increasing order with no overlapping


### PR DESCRIPTION
UPDATE Apr 11: collaborated with @paulshapiro to add endpoints to create or retrieve subaddresses (`/provision_subaddrs`, `/upsert_subaddrs`, `/get_subaddrs`). Also in line with @ndorf 's comment to support this [here](https://github.com/monero-project/meta/pull/647#issuecomment-1007852519).

# Overview

Hoping to reach consensus on how lightwallet servers should support subaddresses @vtnerd @ndorf @paulshapiro @moneroexamples. The changes proposed here are not so major, however a server that supports subaddresses as described would not be backwards compatible with a client that does not. I figure we can keep this proposal as a draft until there is a well-tested server-side and client-side implementation in place everyone is happy with.

Key highlights:

- all endpoints only accept a standard address as the `address` param in requests (**not** subaddresses)
- `/get_address_info`, `/get_address_txs`, and `/get_unspent_outs` return wallet-level data, rather than *just* the info for the standard address
    - these endpoints return address metadata on outputs (`maj_i`, `min_i`) that enables the client to generate key images without needing to re-determine which subaddress received outputs
    - note this is backwards incompatible because a client that does not support subaddresses would not be able to generate key images for outputs received to subaddresses. It would be simple to maintain backwards compatibility if desired by requiring an additional flag in the request to each of these endpoints.
- added 3 new endpoints:
   - `/provision_subaddrs`
     - every successful call is guaranteed to provision fresh subaddresses that have not already been provisioned by the server
   - `/upsert_subaddrs`
     - enables one-off idempotent provisioning of 1 or more subaddresses starting at particular major and/or minor subaddress indexes
   - `/get_subaddrs`
- the server admin can use whatever default lookahead they want (`wallet2` defaults to [50 major * 200 minor](https://github.com/monero-project/monero/blob/319b831e65437f1c8e5ff4b4cb9be03f091f6fc6/src/wallet/wallet2.cpp#L122-L123) e.g.)
- ~the client would manage subaddress creation on its end without touching the server (client adds "accounts" and "addresses within accounts" locally, gives them out to counter-parties when requesting payment, then the server will pick up on the received outputs via a default lookahead when scanning for received outs)~ (UPDATE Apr 11: client can provision subaddresses via the server)


## Existing OpenMonero/monero-lws implementations

Currently `OpenMonero` supports subaddresses in place of the `address` param in all requests. I have a [PR to `monero-lws`](https://github.com/vtnerd/monero-lws/pull/23) that implements this same thing. However, I don't think this will end up being a great way to work with subaddresses in a lightwallet server in production for 3 main reasons:

(1) [This comment](https://github.com/vtnerd/monero-lws/pull/23#issuecomment-1003657389) from @trasherdk:

> Also, I don't see the use-case, where you would need a hosted wallet, for single dedicated sub-addresses, but maybe that's just me. Wasn't sub-addressed supposed to be single use anyway?

It does not seem users would care much for subaddress-level data, and thus it just does not seem sensible for the API and backend to build around subaddress-based "accounts" over the `/login` endpoint.

(2) it's not entirely clear how the client could smoothly retrieve a wallet's (or account's) entire balance. The default lookahead in wallet2 is 50*200 subaddresses, meaning I would guess the expected default for the wallet would be to make 10,000 requests to the server for its balance, which is unrealistic. Then if there are more subaddresses such that the lookahead should be bumped, the client would make more round trips to the server. This does not seem workable.

(3) it requires a quasi-hacky solution to prevent someone malicious from being able to tell that an honest user's subaddress is stored on a server, even if the malicious party doesn't know the honest user's view key. See the `monero-lws` PR for more discussion on this if you have a lot of time and are into that sorta thing.

The goal of this proposal is to support subaddresses in a clean way that avoids the above pitfalls. Thus, I specifically propose *not* to allow subaddresses in place of the `address` param, and instead propose that API implementers follow this proposal to have a good time.

## Future extensions

### Data by subaddress

If we find that clients actually do want to retrieve granular subaddress data over the endpoints, rather than have the server accept a subaddress in the `address` param of requests, requests can include a `major_index` (and `minor_index` if needed) as additional params to the `standard address + view key`. This way the server doesn't need to perform any hacky and potentially unsafe authentication on subaddresses.

### JAMTIS

The idea that the endpoints should support a wallet-level abstraction rather than an address-level abstraction fits neatly with what is brewing with JAMTIS: the current research on the next gen address scheme for Monero. In JAMTIS, a lightwallet server need not even see user addresses at all, and could only return the wallet's plausible received outputs to the client. See [this comment](https://gist.github.com/tevador/50160d160d24cfc6c52ae02eb3d17024#gistcomment-4017963) explaining the brewing design further.

### ~Customizable lookahead~

(UPDATE Apr 11: customizable lookahead not needed anymore. Client can request server create arbitrary counts of new subaddresses)

~If there is demand from lots of individual light wallet users to pre-load tons of subaddresses beyond the default lookahead, the server can also support a user-specified lookahead over the `/login` endpoint for example. This seems like more of a nice-to-have than a necessity imo. I think we can get away without it until the transition to the next gen protocol.~