### PR TITLE
Fixed import_wallet_request path

### DIFF
--- a/api/lightwallet_rest.md
+++ b/api/lightwallet_rest.md
@@ -326,7 +326,7 @@ was actually spent.
 | amount       | `uint64-string`           | The total value in outputs              |
 | outputs      | array of `output` objects | Outputs possibly available for spending |
 
-#### `import_request`
+#### `import_wallet_request`
 Request an account scan from the genesis block.
 
 **Request** object


### PR DESCRIPTION
The API  endpoint `import_request` does not seem to be the correct one as `monero-lws` and `openmonero` both use `import_wallet_request`. Couldn't find any official MyMonero API doc though.